### PR TITLE
Swapped AP puzzle to filter format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ activate
 .idea
 wallets.egg-info
 .venv
-.gitignore
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ activate
 wallets.egg-info
 .venv
 .DS_Store
+.eggs

--- a/authorised_payees/ap_wallet.py
+++ b/authorised_payees/ap_wallet.py
@@ -125,9 +125,9 @@ class APWallet(Wallet):
     # creates the solution that will allow wallet B to spend the coin
     # Wallet B is allowed to make multiple spends but must spend the coin in its entirety
     def ap_make_solution_mode_1(self, outputs=[], my_primary_input=0x0000, my_puzzle_hash=0x0000):
-        sol = "(1 ("
+        sol = "(1 (a) ("
         for puzhash, amount in outputs:
-            sol += f"(0x{hexlify(puzhash).decode('ascii')} {amount})"
+            sol += f"(51 0x{hexlify(puzhash).decode('ascii')} {amount})"
         sol += f") 0x{hexlify(my_primary_input).decode('ascii')} 0x{hexlify(my_puzzle_hash).decode('ascii')})"
         return Program(binutils.assemble(sol))
 

--- a/authorised_payees/ap_wallet.py
+++ b/authorised_payees/ap_wallet.py
@@ -2,7 +2,6 @@ from standard_wallet.wallet import Wallet
 import hashlib
 import clvm
 from chiasim.hashable import Program, ProgramHash, CoinSolution, SpendBundle, BLSSignature
-from binascii import hexlify
 from chiasim.hashable.Coin import Coin
 from chiasim.hashable.CoinSolution import CoinSolutionList
 from clvm_tools import binutils
@@ -88,7 +87,7 @@ class APWallet(Wallet):
         if self.AP_puzzlehash is not None and not self.my_utxos:
             for coin in additions:
                 if coin.puzzle_hash == self.AP_puzzlehash:
-                    self.puzzle_generator = f"(q (c (c (q 0x{hexlify(ConditionOpcode.AGG_SIG).decode('ascii')}) (c (f (a)) (q ()))) (c (c (q 0x{hexlify(ConditionOpcode.ASSERT_COIN_CONSUMED).decode('ascii')}) (c (sha256 (sha256 (f (r (a))) (q 0x{hexlify(self.AP_puzzlehash).decode('ascii')}) (uint64 (f (r (r (a)))))) (sha256 (wrap (c (q 7) (c (c (q 5) (c (c (q 1) (c (f (a)) (q ()))) (c (q (q ())) (q ())))) (q ()))))) (uint64 (q 0))) (q ()))) (q ()))))"
+                    self.puzzle_generator = f"(q (c (c (q 0x{ConditionOpcode.AGG_SIG.hex()}) (c (f (a)) (q ()))) (c (c (q 0x{ConditionOpcode.ASSERT_COIN_CONSUMED.hex()}) (c (sha256 (sha256 (f (r (a))) (q 0x{self.AP_puzzlehash.hex()}) (uint64 (f (r (r (a)))))) (sha256 (wrap (c (q 7) (c (c (q 5) (c (c (q 1) (c (f (a)) (q ()))) (c (q (q ())) (q ())))) (q ()))))) (uint64 (q 0))) (q ()))) (q ()))))"
                     self.puzzle_generator_id = str(ProgramHash(
                         Program(binutils.assemble(self.puzzle_generator))))
                     self.current_balance += coin.amount
@@ -127,16 +126,16 @@ class APWallet(Wallet):
     def ap_make_solution_mode_1(self, outputs=[], my_primary_input=0x0000, my_puzzle_hash=0x0000):
         sol = "(1 (a) ("
         for puzhash, amount in outputs:
-            sol += f"(51 0x{hexlify(puzhash).decode('ascii')} {amount})"
-        sol += f") 0x{hexlify(my_primary_input).decode('ascii')} 0x{hexlify(my_puzzle_hash).decode('ascii')})"
+            sol += f"(0x{ConditionOpcode.CREATE_COIN.hex()} 0x{puzhash.hex()} {amount})"
+        sol += f") 0x{my_primary_input.hex()} 0x{my_puzzle_hash.hex()})"
         return Program(binutils.assemble(sol))
 
     def ac_make_aggregation_solution(self, myid, wallet_coin_primary_input, wallet_coin_amount):
-        sol = f"(0x{hexlify(myid).decode('ascii')} 0x{hexlify(wallet_coin_primary_input).decode('ascii')} {wallet_coin_amount})"
+        sol = f"(0x{myid.hex()} 0x{wallet_coin_primary_input.hex()} {wallet_coin_amount})"
         return Program(binutils.assemble(sol))
 
     def ap_make_solution_mode_2(self, wallet_puzzle_hash, consolidating_primary_input, consolidating_coin_puzzle_hash, outgoing_amount, my_primary_input, incoming_amount):
-        sol = f"(2 0x{hexlify(wallet_puzzle_hash).decode('ascii')} 0x{hexlify(consolidating_primary_input).decode('ascii')} 0x{hexlify(consolidating_coin_puzzle_hash).decode('ascii')} {outgoing_amount} 0x{hexlify(my_primary_input).decode('ascii')} {incoming_amount})"
+        sol = f"(2 0x{wallet_puzzle_hash.hex()} 0x{consolidating_primary_input.hex()} 0x{consolidating_coin_puzzle_hash.hex()} {outgoing_amount} 0x{my_primary_input.hex()} {incoming_amount})"
         return Program(binutils.assemble(sol))
 
     # this is for sending a recieved ap coin, not creating a new ap coin
@@ -224,7 +223,7 @@ class APWallet(Wallet):
         list_of_coinsolutions.append(CoinSolution(
             consolidating_coin, clvm.to_sexp_f([puzzle, solution])))
         # Spend lock
-        puzstring = f"(r (c (q 0x{hexlify(consolidating_coin.name()).decode('ascii')}) (q ())))"
+        puzstring = f"(r (c (q 0x{consolidating_coin.name().hex()}) (q ())))"
         puzzle = Program(binutils.assemble(puzstring))
         solution = Program(binutils.assemble("()"))
         list_of_coinsolutions.append(CoinSolution(Coin(self.temp_coin, ProgramHash(

--- a/authorised_payees/ap_wallet_a_functions.py
+++ b/authorised_payees/ap_wallet_a_functions.py
@@ -1,5 +1,4 @@
 from chiasim.hashable import Program, ProgramHash
-from binascii import hexlify
 from clvm_tools import binutils
 from utilities.puzzle_utilities import pubkey_format
 from chiasim.validation.Conditions import ConditionOpcode
@@ -33,19 +32,20 @@ def ap_make_puzzle(a_pubkey_serialized, b_pubkey_serialized):
     # Solution contains (option 1 flag, list of (output puzzle hash (C/D), amount), my_primary_input, wallet_puzzle_hash)
     sum_outputs = "((c (q ((c (f (a)) (a)))) (c (q ((c (i ((c (i (f (r (a))) (q (q ())) (q (q 1))) (a))) (q (q 0)) (q (+ (f (r (f (f (r (a)))))) ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (q ())))))))) (a)))) (c (f (r (a))) (q ())))))"
 
-    mode_one_me_string = f"(c (q 0x{hexlify(ConditionOpcode.ASSERT_MY_COIN_ID).decode('ascii')}) (c (sha256 (f (r (r (a)))) (f (r (r (r (a))))) (uint64 {sum_outputs})) (q ())))"
-    aggsig_outputs = f"((c (q ((c (f (a)) (a)))) (c (q ((c (i ((c (i (f (r (a))) (q (q ())) (q (q 1))) (a))) (q (q ())) (q (c (c (q 0x{hexlify(ConditionOpcode.AGG_SIG).decode('ascii')}) (c (q {a_pubkey}) (c (f (f (f (r (a))))) (q ())))) ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (q ())))))))) (a)))) (c (f (r (a))) (q ())))))"
-    aggsig_entire_solution = f"(c (q 0x{hexlify(ConditionOpcode.AGG_SIG).decode('ascii')}) (c (q {b_pubkey}) (c (sha256 (wrap (a))) (q ()))))"
-    create_outputs = f"((c (q ((c (f (a)) (a)))) (c (q ((c (i ((c (i (f (r (a))) (q (q ())) (q (q 1))) (a))) (q (q ())) (q (c (c (q 0x{hexlify(ConditionOpcode.CREATE_COIN).decode('ascii')}) (c (f (f (f (r (a))))) (c (f (r (f (f (r (a)))))) (q ())))) ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (q ())))))))) (a)))) (c (f (r (a))) (q ())))))"
+    mode_one_me_string = f"(c (q 0x{ConditionOpcode.ASSERT_MY_COIN_ID.hex()}) (c (sha256 (f (r (r (a)))) (f (r (r (r (a))))) (uint64 {sum_outputs})) (q ())))"
+    aggsig_outputs = f"((c (q ((c (f (a)) (a)))) (c (q ((c (i ((c (i (f (r (a))) (q (q ())) (q (q 1))) (a))) (q (q ())) (q (c (c (q 0x{ConditionOpcode.AGG_SIG.hex()}) (c (q {a_pubkey}) (c (f (f (f (r (a))))) (q ())))) ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (q ())))))))) (a)))) (c (f (r (a))) (q ())))))"
+    aggsig_entire_solution = f"(c (q 0x{ConditionOpcode.AGG_SIG.hex()}) (c (q {b_pubkey}) (c (sha256tree (a)) (q ()))))"
+    create_outputs = f"((c (q ((c (f (a)) (a)))) (c (q ((c (i ((c (i (f (r (a))) (q (q ())) (q (q 1))) (a))) (q (q ())) (q (c (c (q 0x{ConditionOpcode.CREATE_COIN.hex()}) (c (f (f (f (r (a))))) (c (f (r (f (f (r (a)))))) (q ())))) ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (q ())))))))) (a)))) (c (f (r (a))) (q ())))))"
     mode_one = f"(c {aggsig_entire_solution} \
          (c {mode_one_me_string} {aggsig_outputs}))"
     mode_one = merge_two_lists(create_outputs, mode_one)
 
     # Mode two is for aggregating in another coin and expanding our single coin wallet
     # Solution contains (option 2 flag, wallet_puzzle_hash, consolidating_coin_primary_input, consolidating_coin_puzzle_hash, consolidating_coin_amount, my_primary_input, my_amount)
-    create_consolidated = f"(c (q 0x{hexlify(ConditionOpcode.CREATE_COIN).decode('ascii')}) (c (f (r (a))) (c (+ (f (r (r (r (r (a)))))) (f (r (r (r (r (r (r (a))))))))) (q ()))))"
-    mode_two_me_string = f"(c (q 0x{hexlify(ConditionOpcode.ASSERT_MY_COIN_ID).decode('ascii')}) (c (sha256 (f (r (r (r (r (r (a))))))) (f (r (a))) (uint64 (f (r (r (r (r (r (r (a)))))))))) (q ())))"
-    create_lock = f"(c (q 0x{hexlify(ConditionOpcode.CREATE_COIN).decode('ascii')}) (c (sha256 (wrap (c (q 7) (c (c (q 5) (c (c (q 1) (c (sha256 (f (r (r (a)))) (f (r (r (r (a))))) (uint64 (f (r (r (r (r (a)))))))) (q ()))) (c (q (q ())) (q ())))) (q ()))))) (c (uint64 (q 0)) (q ()))))"
+    create_consolidated = f"(c (q 0x{ConditionOpcode.CREATE_COIN.hex()}) (c (f (r (a))) (c (+ (f (r (r (r (r (a)))))) (f (r (r (r (r (r (r (a))))))))) (q ()))))"
+    mode_two_me_string = f"(c (q 0x{ConditionOpcode.ASSERT_MY_COIN_ID.hex()}) (c (sha256 (f (r (r (r (r (r (a))))))) (f (r (a))) (uint64 (f (r (r (r (r (r (r (a)))))))))) (q ())))"
+    create_lock = f"(c (q 0x{ConditionOpcode.CREATE_COIN.hex()}) (c (sha256tree (c (q 7) (c (c (q 5) (c (c (q 1) (c (sha256 (f (r (r (a)))) (f (r (r (r (a))))) (uint64 (f (r (r (r (r (a)))))))) (q ()))) (c (q (q ())) (q ())))) (q ())))) (c (uint64 (q 0)) (q ()))))"
+
     mode_two = f"(c {mode_two_me_string} (c {aggsig_entire_solution} \
          (c {create_lock} (c {create_consolidated} (q ())))))"
 
@@ -56,14 +56,11 @@ def ap_make_puzzle(a_pubkey_serialized, b_pubkey_serialized):
 def ap_make_aggregation_puzzle(wallet_puzzle):
     # If Wallet A wants to send further funds to Wallet B then they can lock them up using this code
     # Solution will be (my_id wallet_coin_primary_input wallet_coin_amount)
-    me_is_my_id = '(c (q 0x%s) (c (f (a)) (q ())))' % (
-        hexlify(ConditionOpcode.ASSERT_MY_COIN_ID).decode('ascii'))
+    me_is_my_id = f'(c (q 0x{ConditionOpcode.ASSERT_MY_COIN_ID.hex()}) (c (f (a)) (q ())))'
     # lock_puzzle is the hash of '(r (c (q "merge in ID") (q ())))'
-    lock_puzzle = '(sha256 (wrap (c (q 7) (c (c (q 5) (c (c (q 1) (c (f (a)) (q ()))) (c (q (q ())) (q ())))) (q ())))))'
-    parent_coin_id = "(sha256 (f (r (a))) (q 0x%s) (uint64 (f (r (r (a))))))" % hexlify(
-        wallet_puzzle).decode('ascii')
-    input_of_lock = '(c (q 0x%s) (c (sha256 %s %s (uint64 (q 0))) (q ())))' % (hexlify(
-        ConditionOpcode.ASSERT_COIN_CONSUMED).decode('ascii'), parent_coin_id, lock_puzzle)
+    lock_puzzle = '(sha256tree (c (q 7) (c (c (q 5) (c (c (q 1) (c (f (a)) (q ()))) (c (q (q ())) (q ())))) (q ()))))'
+    parent_coin_id = f"(sha256 (f (r (a))) (q 0x{wallet_puzzle.hex()}) (uint64 (f (r (r (a))))))"
+    input_of_lock = f'(c (q 0x{ConditionOpcode.ASSERT_COIN_CONSUMED.hex()}) (c (sha256 {parent_coin_id} {lock_puzzle} (uint64 (q 0))) (q ())))'
     puz = f"(c {me_is_my_id} (c {input_of_lock} (q ())))"
     return Program(binutils.assemble(puz))
 

--- a/authorised_payees/ap_wallet_a_functions.py
+++ b/authorised_payees/ap_wallet_a_functions.py
@@ -50,7 +50,7 @@ def ap_make_puzzle(a_pubkey_serialized, b_pubkey_serialized):
          (c {create_lock} (c {create_consolidated} (q ())))))"
 
     puz = f"((c (i (= (f (a)) (q 1)) (q {mode_one}) (q {mode_two})) (a)))"
-    breakpoint()
+    #breakpoint()
     return Program(binutils.assemble(puz))
 
 

--- a/authorised_payees/ap_wallet_a_functions.py
+++ b/authorised_payees/ap_wallet_a_functions.py
@@ -34,8 +34,8 @@ def ap_make_puzzle(a_pubkey_serialized, b_pubkey_serialized):
 
     aggsig_entire_solution = f"(c (q 0x{ConditionOpcode.AGG_SIG.hex()}) (c (q {b_pubkey}) (c (sha256tree (a)) (q ()))))"
     create_outputs = f"((c (f (r (a))) (f (r (r (a))))))"
-    aggsig_outputs = f"((c (q ((c (f (a)) (a)))) (c (q ((c (i (f (r (a))) (q ((c (i (= (f (f (f (r (a))))) (q 51)) (q ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (c (c (c (q 50) (c (q {a_pubkey}) (c (f (r (f (f (r (a)))))) (q ())))) (f (r (r (a))))) (q ()))))))) (q ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (c (f (r (r (a)))) (q ())))))))) (a)))) (q (f (r (r (a)))))) (a)))) (c {create_outputs} (c {create_outputs} (q ()))))))"
-    sum_outputs = f"((c (q ((c (f (a)) (a)))) (c (q ((c (i (f (r (a))) (q ((c (i (= (f (f (f (r (a))))) (q 51)) (q (+ (f (r (r (f (f (r (a))))))) ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (q ()))))))) (q (+ (q ()) ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (q ())))))))) (a)))) (q (q ()))) (a)))) (c {create_outputs} (q ())))))"
+    aggsig_outputs = f"((c (q ((c (f (a)) (a)))) (c (q ((c (i (f (r (a))) (q ((c (i (= (f (f (f (r (a))))) (q 0x{ConditionOpcode.CREATE_COIN.hex()})) (q ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (c (c (c (q 0x{ConditionOpcode.AGG_SIG.hex()}) (c (q {a_pubkey}) (c (f (r (f (f (r (a)))))) (q ())))) (f (r (r (a))))) (q ()))))))) (q ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (c (f (r (r (a)))) (q ())))))))) (a)))) (q (f (r (r (a)))))) (a)))) (c {create_outputs} (c {create_outputs} (q ()))))))"
+    sum_outputs = f"((c (q ((c (f (a)) (a)))) (c (q ((c (i (f (r (a))) (q ((c (i (= (f (f (f (r (a))))) (q 0x{ConditionOpcode.CREATE_COIN.hex()})) (q (+ (f (r (r (f (f (r (a))))))) ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (q ()))))))) (q (+ (q ()) ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (q ())))))))) (a)))) (q (q ()))) (a)))) (c {create_outputs} (q ())))))"
     mode_one_me_string = f"(c (q 0x{ConditionOpcode.ASSERT_MY_COIN_ID.hex()}) (c (sha256 (f (r (r (r (a))))) (f (r (r (r (r (a)))))) (uint64 {sum_outputs})) (q ())))"
     mode_one = f"(c {aggsig_entire_solution} (c {mode_one_me_string} {aggsig_outputs}))"
     #mode_one = merge_two_lists(create_outputs, mode_one)

--- a/authorised_payees/ap_wallet_a_functions.py
+++ b/authorised_payees/ap_wallet_a_functions.py
@@ -50,7 +50,6 @@ def ap_make_puzzle(a_pubkey_serialized, b_pubkey_serialized):
          (c {create_lock} (c {create_consolidated} (q ())))))"
 
     puz = f"((c (i (= (f (a)) (q 1)) (q {mode_one}) (q {mode_two})) (a)))"
-    #breakpoint()
     return Program(binutils.assemble(puz))
 
 

--- a/authorised_payees/ap_wallet_a_functions.py
+++ b/authorised_payees/ap_wallet_a_functions.py
@@ -29,16 +29,16 @@ def ap_make_puzzle(a_pubkey_serialized, b_pubkey_serialized):
     b_pubkey = pubkey_format(b_pubkey_serialized)
 
     # Mode one is for spending to one of the approved destinations
-    # Solution contains (option 1 flag, list of (output puzzle hash (C/D), amount), my_primary_input, wallet_puzzle_hash)
-    sum_outputs = "((c (q ((c (f (a)) (a)))) (c (q ((c (i ((c (i (f (r (a))) (q (q ())) (q (q 1))) (a))) (q (q 0)) (q (+ (f (r (f (f (r (a)))))) ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (q ())))))))) (a)))) (c (f (r (a))) (q ())))))"
+    # Solution contains (option 1 flag, new puzzle, new solution, my_primary_input, wallet_puzzle_hash)
 
-    mode_one_me_string = f"(c (q 0x{ConditionOpcode.ASSERT_MY_COIN_ID.hex()}) (c (sha256 (f (r (r (a)))) (f (r (r (r (a))))) (uint64 {sum_outputs})) (q ())))"
-    aggsig_outputs = f"((c (q ((c (f (a)) (a)))) (c (q ((c (i ((c (i (f (r (a))) (q (q ())) (q (q 1))) (a))) (q (q ())) (q (c (c (q 0x{ConditionOpcode.AGG_SIG.hex()}) (c (q {a_pubkey}) (c (f (f (f (r (a))))) (q ())))) ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (q ())))))))) (a)))) (c (f (r (a))) (q ())))))"
+
     aggsig_entire_solution = f"(c (q 0x{ConditionOpcode.AGG_SIG.hex()}) (c (q {b_pubkey}) (c (sha256tree (a)) (q ()))))"
-    create_outputs = f"((c (q ((c (f (a)) (a)))) (c (q ((c (i ((c (i (f (r (a))) (q (q ())) (q (q 1))) (a))) (q (q ())) (q (c (c (q 0x{ConditionOpcode.CREATE_COIN.hex()}) (c (f (f (f (r (a))))) (c (f (r (f (f (r (a)))))) (q ())))) ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (q ())))))))) (a)))) (c (f (r (a))) (q ())))))"
-    mode_one = f"(c {aggsig_entire_solution} \
-         (c {mode_one_me_string} {aggsig_outputs}))"
-    mode_one = merge_two_lists(create_outputs, mode_one)
+    create_outputs = f"((c (f (r (a))) (f (r (r (a))))))"
+    aggsig_outputs = f"((c (q ((c (f (a)) (a)))) (c (q ((c (i (f (r (a))) (q ((c (i (= (f (f (f (r (a))))) (q 51)) (q ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (c (c (c (q 50) (c (q {a_pubkey}) (c (f (r (f (f (r (a)))))) (q ())))) (f (r (r (a))))) (q ()))))))) (q ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (c (f (r (r (a)))) (q ())))))))) (a)))) (q (f (r (r (a)))))) (a)))) (c {create_outputs} (c {create_outputs} (q ()))))))"
+    sum_outputs = f"((c (q ((c (f (a)) (a)))) (c (q ((c (i (f (r (a))) (q ((c (i (= (f (f (f (r (a))))) (q 51)) (q (+ (f (r (r (f (f (r (a))))))) ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (q ()))))))) (q (+ (q ()) ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (q ())))))))) (a)))) (q (q ()))) (a)))) (c {create_outputs} (q ())))))"
+    mode_one_me_string = f"(c (q 0x{ConditionOpcode.ASSERT_MY_COIN_ID.hex()}) (c (sha256 (f (r (r (r (a))))) (f (r (r (r (r (a)))))) (uint64 {sum_outputs})) (q ())))"
+    mode_one = f"(c {aggsig_entire_solution} (c {mode_one_me_string} {aggsig_outputs}))"
+    #mode_one = merge_two_lists(create_outputs, mode_one)
 
     # Mode two is for aggregating in another coin and expanding our single coin wallet
     # Solution contains (option 2 flag, wallet_puzzle_hash, consolidating_coin_primary_input, consolidating_coin_puzzle_hash, consolidating_coin_amount, my_primary_input, my_amount)
@@ -50,6 +50,7 @@ def ap_make_puzzle(a_pubkey_serialized, b_pubkey_serialized):
          (c {create_lock} (c {create_consolidated} (q ())))))"
 
     puz = f"((c (i (= (f (a)) (q 1)) (q {mode_one}) (q {mode_two})) (a)))"
+    breakpoint()
     return Program(binutils.assemble(puz))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
+-e git+git@github.com:Chia-Network/clvm.git@5befca8c6d0b2232f21b1a3a5ff27ac8caddc9b6#egg=clvm
+-e git+git@github.com:Chia-Network/clvm_tools.git@1c4f4cbf159a89385c90647e31a2572d04d09cfd#egg=clvm_tools
+-e git+git@github.com:Chia-Network/ledger_sim.git@072ca55ed26e2bb2703e9b56bc26e810c06683f3#egg=ledger_sim
 aiter==0.1.2
 blspy==0.1.8
 cbor==1.0.0
 qrcode==6.1
 pyzbar==0.1.8
 Pillow==6.2.1
--e git+git@github.com:Chia-Network/clvm.git#egg=clvm
--e git+git@github.com:Chia-Network/ledger_sim.git#egg=ledger_sim
--e git+git@github.com:Chia-Network/clvm_tools.git#egg=clvm_tools

--- a/standard_wallet/wallet.py
+++ b/standard_wallet/wallet.py
@@ -15,7 +15,6 @@ from chiasim.validation.consensus import (
     conditions_for_solution, hash_key_pairs_for_conditions_dict
 )
 from chiasim.wallet.BLSPrivateKey import BLSPrivateKey
-from binascii import hexlify
 from chiasim.validation.Conditions import ConditionOpcode
 
 
@@ -41,7 +40,7 @@ class Wallet:
     seed = b'seed'
     next_address = 0
     pubkey_num_lookup = {}
-    puzzle_generator = f"(c (q 5) (c (c (q 5) (c (q (q 0x{hexlify(ConditionOpcode.AGG_SIG).decode('ascii')})) (c (c (q 5) (c (c (q 1) (c (f (a)) (q ()))) (q ((c (sha256 (wrap (f (a)))) (q ())))))) (q ())))) (q (((c (f (a)) (f (r (a)))))))))"
+    puzzle_generator = f"(c (q 5) (c (c (q 5) (c (q (q 0x{ConditionOpcode.AGG_SIG.hex()})) (c (c (q 5) (c (c (q 1) (c (f (a)) (q ()))) (q ((c (sha256 (wrap (f (a)))) (q ())))))) (q ())))) (q (((c (f (a)) (f (r (a)))))))))"
     puzzle_generator_id = str(ProgramHash(
         Program(binutils.assemble(puzzle_generator))))
 


### PR DESCRIPTION
The AP puzzle now runs x1 and x2 as puzzle and solution to generate output conditions and adds the condition that all created coins must have a signature in aggsig.

The default behaviour is for x1 to be (a) and x2 to be a list of create coin opcodes from the known approved puzzlehash list.

This branch also updates to f-strings, removes hexlify, and updates to Chialisp 0.3