### PR TITLE
Remove uint64.

### DIFF
--- a/authorised_payees/ap_wallet_a_functions.py
+++ b/authorised_payees/ap_wallet_a_functions.py
@@ -35,15 +35,15 @@ def ap_make_puzzle(a_pubkey_serialized, b_pubkey_serialized):
     create_outputs = f"((c (f (r (a))) (f (r (r (a))))))"
     aggsig_outputs = f"((c (q ((c (f (a)) (a)))) (c (q ((c (i (f (r (a))) (q ((c (i (= (f (f (f (r (a))))) (q 0x{ConditionOpcode.CREATE_COIN.hex()})) (q ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (c (c (c (q 0x{ConditionOpcode.AGG_SIG.hex()}) (c (q {a_pubkey}) (c (f (r (f (f (r (a)))))) (q ())))) (f (r (r (a))))) (q ()))))))) (q ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (c (f (r (r (a)))) (q ())))))))) (a)))) (q (f (r (r (a)))))) (a)))) (c {create_outputs} (c {create_outputs} (q ()))))))"
     sum_outputs = f"((c (q ((c (f (a)) (a)))) (c (q ((c (i (f (r (a))) (q ((c (i (= (f (f (f (r (a))))) (q 0x{ConditionOpcode.CREATE_COIN.hex()})) (q (+ (f (r (r (f (f (r (a))))))) ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (q ()))))))) (q (+ (q ()) ((c (f (a)) (c (f (a)) (c (r (f (r (a)))) (q ())))))))) (a)))) (q (q ()))) (a)))) (c {create_outputs} (q ())))))"
-    mode_one_me_string = f"(c (q 0x{ConditionOpcode.ASSERT_MY_COIN_ID.hex()}) (c (sha256 (f (r (r (r (a))))) (f (r (r (r (r (a)))))) (uint64 {sum_outputs})) (q ())))"
+    mode_one_me_string = f"(c (q 0x{ConditionOpcode.ASSERT_MY_COIN_ID.hex()}) (c (sha256 (f (r (r (r (a))))) (f (r (r (r (r (a)))))) {sum_outputs}) (q ())))"
     mode_one = f"(c {aggsig_entire_solution} (c {mode_one_me_string} {aggsig_outputs}))"
     #mode_one = merge_two_lists(create_outputs, mode_one)
 
     # Mode two is for aggregating in another coin and expanding our single coin wallet
     # Solution contains (option 2 flag, wallet_puzzle_hash, consolidating_coin_primary_input, consolidating_coin_puzzle_hash, consolidating_coin_amount, my_primary_input, my_amount)
     create_consolidated = f"(c (q 0x{ConditionOpcode.CREATE_COIN.hex()}) (c (f (r (a))) (c (+ (f (r (r (r (r (a)))))) (f (r (r (r (r (r (r (a))))))))) (q ()))))"
-    mode_two_me_string = f"(c (q 0x{ConditionOpcode.ASSERT_MY_COIN_ID.hex()}) (c (sha256 (f (r (r (r (r (r (a))))))) (f (r (a))) (uint64 (f (r (r (r (r (r (r (a)))))))))) (q ())))"
-    create_lock = f"(c (q 0x{ConditionOpcode.CREATE_COIN.hex()}) (c (sha256tree (c (q 7) (c (c (q 5) (c (c (q 1) (c (sha256 (f (r (r (a)))) (f (r (r (r (a))))) (uint64 (f (r (r (r (r (a)))))))) (q ()))) (c (q (q ())) (q ())))) (q ())))) (c (uint64 (q 0)) (q ()))))"
+    mode_two_me_string = f"(c (q 0x{ConditionOpcode.ASSERT_MY_COIN_ID.hex()}) (c (sha256 (f (r (r (r (r (r (a))))))) (f (r (a))) (f (r (r (r (r (r (r (a))))))))) (q ())))"
+    create_lock = f"(c (q 0x{ConditionOpcode.CREATE_COIN.hex()}) (c (sha256tree (c (q 7) (c (c (q 5) (c (c (q 1) (c (sha256 (f (r (r (a)))) (f (r (r (r (a))))) (f (r (r (r (r (a))))))) (q ()))) (c (q (q ())) (q ())))) (q ())))) (c (q 0) (q ()))))"
 
     mode_two = f"(c {mode_two_me_string} (c {aggsig_entire_solution} \
          (c {create_lock} (c {create_consolidated} (q ())))))"
@@ -58,8 +58,8 @@ def ap_make_aggregation_puzzle(wallet_puzzle):
     me_is_my_id = f'(c (q 0x{ConditionOpcode.ASSERT_MY_COIN_ID.hex()}) (c (f (a)) (q ())))'
     # lock_puzzle is the hash of '(r (c (q "merge in ID") (q ())))'
     lock_puzzle = '(sha256tree (c (q 7) (c (c (q 5) (c (c (q 1) (c (f (a)) (q ()))) (c (q (q ())) (q ())))) (q ()))))'
-    parent_coin_id = f"(sha256 (f (r (a))) (q 0x{wallet_puzzle.hex()}) (uint64 (f (r (r (a))))))"
-    input_of_lock = f'(c (q 0x{ConditionOpcode.ASSERT_COIN_CONSUMED.hex()}) (c (sha256 {parent_coin_id} {lock_puzzle} (uint64 (q 0))) (q ())))'
+    parent_coin_id = f"(sha256 (f (r (a))) (q 0x{wallet_puzzle.hex()}) (f (r (r (a)))))"
+    input_of_lock = f'(c (q 0x{ConditionOpcode.ASSERT_COIN_CONSUMED.hex()}) (c (sha256 {parent_coin_id} {lock_puzzle} (q 0)) (q ())))'
     puz = f"(c {me_is_my_id} (c {input_of_lock} (q ())))"
     return Program(binutils.assemble(puz))
 

--- a/docs/part1_basics.md
+++ b/docs/part1_basics.md
@@ -24,7 +24,7 @@ Internally however the blobs can be interpreted in a number of different ways, w
 There are no support for floating point numbers in ChiaLisp, only integers.
 Internally integers are interpreted as 256 bit signed integers.
 
-The math operators are `*`, `+`, `-`, and `uint64`.
+The math operators are `*`, `+`, and `-`.
 
 ```
 $ brun '(- (q 6) (q 5))' '()'
@@ -35,10 +35,6 @@ $ brun '(* (q 2) (q 4) (q 5))' '()'
 
 $ brun '(+ (q 10) (q 20) (q 30) (q 40))' '()'
 100
-
-$ $ brun '(uint64 (q 10))' '()'
-0x000000000000000a
-```
 
 You may have noticed that the multiplication example above takes more than two parameters in the list.
 This is because many operators can take variable amounts of parameters.

--- a/docs/part2_transactions.md
+++ b/docs/part2_transactions.md
@@ -29,7 +29,7 @@ Here is the actual code that defines a coin:
 class Coin:
     parent_coin_info: "CoinName"
     puzzle_hash: ProgramHash
-    amount: clvm_int
+    amount: uint64
 ```
 
 ## Spends

--- a/docs/part2_transactions.md
+++ b/docs/part2_transactions.md
@@ -29,7 +29,7 @@ Here is the actual code that defines a coin:
 class Coin:
     parent_coin_info: "CoinName"
     puzzle_hash: ProgramHash
-    amount: uint64
+    amount: clvm_int
 ```
 
 ## Spends

--- a/rate_limit/rl_wallet.py
+++ b/rate_limit/rl_wallet.py
@@ -136,19 +136,19 @@ class RLWallet(Wallet):
         if (not origin_id):
             return None
 
-        TEMPLATE_MY_PARENT_ID = "(sha256 (f (r (r (r (r (r (r (a)))))))) (f (r (a))) (uint64 (f (r (r (r (r (r (r (r (a)))))))))))"
+        TEMPLATE_MY_PARENT_ID = "(sha256 (f (r (r (r (r (r (r (a)))))))) (f (r (a))) (f (r (r (r (r (r (r (r (a))))))))))"
         TEMPLATE_SINGLETON_RL = f"((c (i (i (= {TEMPLATE_MY_PARENT_ID} (f (a))) (q 1) (= (f (a)) (q 0x{origin_id}))) (q (c (q 1) (q ()))) (q (x (q \"Parent doesnt satisfy RL conditions\")))) (a)))"
         TEMPLATE_BLOCK_AGE = f"((c (i (i (= (* (f (r (r (r (r (r (a))))))) (q {rate_amount})) (* (f (r (r (r (r (a)))))) (q {interval_time}))) (q 1) (q (> (* (f (r (r (r (r (r (a))))))) (q {rate_amount})) (* (f (r (r (r (r (a))))))) (q {interval_time})))) (q (c (q 0x{opcode_coin_block_age}) (c (f (r (r (r (r (r (a))))))) (q ())))) (q (x (q \"wrong min block time\")))) (a) ))"
-        TEMPLATE_MY_ID = f"(c (q 0x{opcode_myid}) (c (sha256 (f (a)) (f (r (a))) (uint64 (f (r (r (a)))))) (q ())))"
+        TEMPLATE_MY_ID = f"(c (q 0x{opcode_myid}) (c (sha256 (f (a)) (f (r (a))) (f (r (r (a))))) (q ())))"
         CREATE_CHANGE = f"(c (q 0x{opcode_create}) (c (f (r (a))) (c (- (f (r (r (a)))) (f (r (r (r (r (a))))))) (q ()))))"
         CREATE_NEW_COIN = f"(c (q 0x{opcode_create}) (c (f (r (r (r (a))))) (c (f (r (r (r (r (a)))))) (q ()))))"
         RATE_LIMIT_PUZZLE = f"(c {TEMPLATE_SINGLETON_RL} (c {TEMPLATE_BLOCK_AGE} (c {CREATE_CHANGE} (c {TEMPLATE_MY_ID} (c {CREATE_NEW_COIN} (q ()))))))"
 
-        TEMPLATE_MY_PARENT_ID_2 = "(sha256 (f (r (r (r (r (r (r (r (r (a)))))))))) (f (r (a))) (uint64 (f (r (r (r (r (r (r (r (a)))))))))))"
+        TEMPLATE_MY_PARENT_ID_2 = "(sha256 (f (r (r (r (r (r (r (r (r (a)))))))))) (f (r (a))) (f (r (r (r (r (r (r (r (a))))))))))"
         TEMPLATE_SINGLETON_RL_2 = f"((c (i (i (= {TEMPLATE_MY_PARENT_ID_2} (f (r (r (r (r (r (a)))))))) (q 1) (= (f (r (r (r (r (r (a))))))) (q 0x{origin_id}))) (q (c (q 1) (q ()))) (q (x (q \"Parent doesnt satisfy RL conditions\")))) (a)))"
         CREATE_CONSOLIDATED = f"(c (q 0x{opcode_create}) (c (f (r (a))) (c (+ (f (r (r (r (r (a)))))) (f (r (r (r (r (r (r (a))))))))) (q ()))))"
-        MODE_TWO_ME_STRING = f"(c (q 0x{opcode_myid}) (c (sha256 (f (r (r (r (r (r (a))))))) (f (r (a))) (uint64 (f (r (r (r (r (r (r (a)))))))))) (q ())))"
-        CREATE_LOCK = f"(c (q 0x{opcode_create}) (c (sha256tree (c (q 7) (c (c (q 5) (c (c (q 1) (c (sha256 (f (r (r (a)))) (f (r (r (r (a))))) (uint64 (f (r (r (r (r (a)))))))) (q ()))) (c (q (q ())) (q ())))) (q ())))) (c (uint64 (q 0)) (q ()))))"
+        MODE_TWO_ME_STRING = f"(c (q 0x{opcode_myid}) (c (sha256 (f (r (r (r (r (r (a))))))) (f (r (a))) (f (r (r (r (r (r (r (a))))))))) (q ())))"
+        CREATE_LOCK = f"(c (q 0x{opcode_create}) (c (sha256tree (c (q 7) (c (c (q 5) (c (c (q 1) (c (sha256 (f (r (r (a)))) (f (r (r (r (a))))) (f (r (r (r (r (a))))))) (q ()))) (c (q (q ())) (q ())))) (q ())))) (c (q 0) (q ()))))"
 
         MODE_TWO = f"(c {TEMPLATE_SINGLETON_RL_2} (c {MODE_TWO_ME_STRING} (c {CREATE_LOCK} (c {CREATE_CONSOLIDATED} (q ())))))"
 
@@ -169,8 +169,8 @@ class RLWallet(Wallet):
 
         # lock_puzzle is the hash of '(r (c (q "merge in ID") (q ())))'
         lock_puzzle = "(sha256tree (c (q 7) (c (c (q 5) (c (c (q 1) (c (f (a)) (q ()))) (c (q (q ())) (q ())))) (q ()))))"
-        parent_coin_id = f"(sha256 (f (r (a))) (q 0x{wallet_puzzle}) (uint64 (f (r (r (a))))))"
-        input_of_lock = f"(c (q 0x{opcode_consumed}) (c (sha256 {parent_coin_id} {lock_puzzle} (uint64 (q 0))) (q ())))"
+        parent_coin_id = f"(sha256 (f (r (a))) (q 0x{wallet_puzzle}) (f (r (r (a)))))"
+        input_of_lock = f"(c (q 0x{opcode_consumed}) (c (sha256 {parent_coin_id} {lock_puzzle} (q 0)) (q ())))"
         puz = f"(c {me_is_my_id} (c {input_of_lock} (q ())))"
 
         return Program(binutils.assemble(puz))

--- a/recoverable_wallet/chialisp.py
+++ b/recoverable_wallet/chialisp.py
@@ -69,10 +69,6 @@ def sha256tree(*argv):
     return apply('sha256tree', argv)
 
 
-def uint64(obj):
-    return sexp('uint64', obj)
-
-
 def equal(*argv):
     return apply('=', argv)
 

--- a/recoverable_wallet/recoverable_wallet.py
+++ b/recoverable_wallet/recoverable_wallet.py
@@ -130,7 +130,7 @@ class RecoverableWallet(Wallet):
                                          multiply(value, stake_factor_numerator)),
                                    make_list(quote(op_create), quote(escrow_puzzlehash), new_value),
                                    fail())
-        coin_id = sha256(parent, puzzle_hash, uint64(value))
+        coin_id = sha256(parent, puzzle_hash, value)
         consumed_condition = make_list(quote(op_consumed), coin_id)
         escrow_conditions = make_list(create_condition,
                                       consumed_condition)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e git+https://git@github.com/Chia-Network/clvm.git@134c2f92d575a542272ce0cbe59c167b255e50ae#egg=clvm
--e git+https://git@github.com/Chia-Network/clvm_tools.git@aca0c1577991a9349df53817249d0088656c7608#egg=clvm_tools
--e git+https://git@github.com/Chia-Network/ledger_sim.git@ca99e6e9a4cbbf95ace17f9b4a64812bf7368189#egg=ledger_sim
+-e git+https://git@github.com/Chia-Network/clvm_tools.git@208dc0bbf41e16d8e5dd8cbc1510e1528a48bbe1#egg=clvm_tools
+-e git+https://git@github.com/Chia-Network/ledger_sim.git@be41ec4f805ad6dcb25a6e8d512ccc2cb60caed8#egg=ledger_sim
 aiter==0.1.2
 blspy==0.1.8
 cbor==1.0.0


### PR DESCRIPTION
This changes how `Coin` is streaming in ledger sim, removing the need for the weird and annoying clvm opcode `uint64` (in return for making how `Coin` streams a little weird and annoying, and slightly different from what `bytes(coin)` returns).